### PR TITLE
Fixed crash in lecturesFragment

### DIFF
--- a/app/src/main/java/de/tum/ase/aatqrgenerator/fragment/LecturesFragment.java
+++ b/app/src/main/java/de/tum/ase/aatqrgenerator/fragment/LecturesFragment.java
@@ -65,10 +65,15 @@ public class LecturesFragment extends Fragment {
 
         apiService.setAttendanceListener(new ApiService.ApiAttendanceListener() {
             @Override
-            public void attendanceCreated(String verificationToken) {
+            public void attendanceCreated(final String verificationToken) {
                 Log.d("LecturesFragment", "attendance created with verification token: " + verificationToken);
                 if(getActivity() instanceof MainActivity){
-                    ((MainActivity) getActivity()).showQr(verificationToken);
+                    getActivity().runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            ((MainActivity) getActivity()).showQr(verificationToken);
+                        }
+                    });
                 }
             }
 


### PR DESCRIPTION
When tapping a lecture that has not been attended, the application would try to cal a UI method from the OkHttp thread and this raises an exception, added runOnUiThread to fix that